### PR TITLE
fix: 修正配置国密证书示例

### DIFF
--- a/docs/features/angie.md
+++ b/docs/features/angie.md
@@ -84,7 +84,7 @@ $ make install
 
     # can be combined with regular RSA certificate:
     ssl_certificate  rsa.crt;
-    ssl_certificate  rsa.key;
+    ssl_certificate_key  rsa.key;
     ```
 
 - 配置国密套件


### PR DESCRIPTION
ssl_certificate 和 ssl_certificate_key